### PR TITLE
Drop Documenter from deps + bump patch release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ notifications:
   email: false
 
 julia:
-  - 1.0.5
-  - 1.6.6
+  - 1.6
+  - 1.8
   - nightly
 
 os:
@@ -27,12 +27,12 @@ jobs:
     - julia: nightly
   include:
     - stage: "Documentation"
-      julia: 1.6.6
+      julia: 1.6
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg;
-                                               Pkg.develop(PackageSpec(path=pwd()));
-                                               Pkg.instantiate()'
+                                    Pkg.develop(PackageSpec(path=pwd()));
+                                    Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
       after_success: skip
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "SphericalGeometry"
 uuid = "b58e7a8d-b3e8-4a5d-bea9-e6440cab77fd"
 authors = ["René Verbeek"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]


### PR DESCRIPTION
I don't think we want Documenter as a dependency of this package. It enforced version downgrades of packages when I added SphericalGeometry as a dep in a different package.

This PR removes Documenter from being a package dependency and bumps up a patch release.

resolves #10